### PR TITLE
autocomplete: Emit empty value to show whole record

### DIFF
--- a/src/app/autocomplete-input/autocomplete-input.component.html
+++ b/src/app/autocomplete-input/autocomplete-input.component.html
@@ -1,5 +1,5 @@
-<input [(ngModel)]="value" [typeahead]="dataSource" (typeaheadNoResults)="typeaheadNoResults = $event"
+<input [ngModel]="value" (ngModelChange)="modelChange($event)" [typeahead]="dataSource" (typeaheadNoResults)="typeaheadNoResults = $event"
        (typeaheadOnSelect)="selectUserInput($event)" [disabled]="disabled" [attr.class]="className" [typeaheadMinLength]="0">
-<div *ngIf="typeaheadNoResults===true">
+<div *ngIf="typeaheadNoResults === true">
   <i class="fa fa-remove"></i> No Results Found
 </div>

--- a/src/app/shared/services/schema-keys-store.service.ts
+++ b/src/app/shared/services/schema-keys-store.service.ts
@@ -7,7 +7,6 @@ export class SchemaKeysStoreService {
 
   public readonly separator = '.';
   public schemaKeyStoreMap: { [path: string]: OrderedSet<string> } = {};
-  public recordKeysStoreMap: any = {};
   public schema = {};
 
   constructor() { }


### PR DESCRIPTION
Currently after you have filtered something there is no way to see again the whole record. For this reason  empty path is emitted  so the `MultiEditorComponent` can show the whole records.