### PR TITLE
separator: Change schema separator to `.`

### DIFF
--- a/src/app/autocomplete-input/autocomplete-input.component.ts
+++ b/src/app/autocomplete-input/autocomplete-input.component.ts
@@ -18,7 +18,6 @@ export class AutocompleteInputComponent {
   @Output() valueChange = new EventEmitter<string>();
   value = '';
 
-  private readonly separator = '/';
   currentPath = '';
   dataSource: Observable<any>;
 
@@ -41,14 +40,14 @@ export class AutocompleteInputComponent {
   }
 
   selectUserInput(event) {
-    this.value = this.currentPath !== '' ? `${this.currentPath}${this.separator}${event.value}` : event.value;
+    this.value = this.currentPath !== '' ? `${this.currentPath}${this.schemaKeysStoreService.separator}${event.value}` : event.value;
     this.valueChange.emit(this.value);
   }
 
   private getStateForValue(value): ParsedAutocompleteInput {
     let path = '';
     let query = '';
-    let separatorIndex = value.lastIndexOf(this.separator);
+    let separatorIndex = value.lastIndexOf(this.schemaKeysStoreService.separator);
     if (separatorIndex < 0) {
       path = '';
       query = value;

--- a/src/app/shared/pipes/tag-filter.pipe.spec.ts
+++ b/src/app/shared/pipes/tag-filter.pipe.spec.ts
@@ -73,7 +73,7 @@ describe('TagFilterPipe', () => {
         ]
       }]
     }];
-    let result = pipe.transform(records, 'authors/affiliations/value');
+    let result = pipe.transform(records, 'authors.affiliations.value');
     expect(result).toEqual(expected);
   });
 });

--- a/src/app/shared/services/json-utils.service.spec.ts
+++ b/src/app/shared/services/json-utils.service.spec.ts
@@ -60,7 +60,7 @@ describe('JsonUtilsService', () => {
       ]
     };
 
-    let result = service.filterObject(record, ['authors/affiliations/value', 'authors/full_name']);
+    let result = service.filterObject(record, ['authors.affiliations.value', 'authors.full_name']);
     expect(result).toEqual(expected);
   });
 
@@ -104,7 +104,7 @@ describe('JsonUtilsService', () => {
         full_name: 'dummy'
       }
     ]};
-    let tags = ['authors/affiliations/value', 'authors/full_name'];
+    let tags = ['authors.affiliations.value', 'authors.full_name'];
     let result = service.filterObject(record, tags);
     expect(result).toEqual(expected);
   });

--- a/src/app/shared/services/schema-keys-store.service.spec.ts
+++ b/src/app/shared/services/schema-keys-store.service.spec.ts
@@ -52,9 +52,9 @@ describe('SchemaKeysStoreService', () => {
     };
     let expectedMap = {
       '': OrderedSet(['anArray']),
-      '/anArray': OrderedSet(['anObject', 'aString', 'innerArray']),
-      '/anArray/anObject': OrderedSet(['prop1', 'prop2']),
-      '/anArray/innerArray': OrderedSet(['prop1', 'prop2'])
+      '.anArray': OrderedSet(['anObject', 'aString', 'innerArray']),
+      '.anArray.anObject': OrderedSet(['prop1', 'prop2']),
+      '.anArray.innerArray': OrderedSet(['prop1', 'prop2'])
     };
 
     service.buildSchemaKeyStore(schema);
@@ -122,7 +122,7 @@ describe('SchemaKeysStoreService', () => {
     };
 
     service.buildSchemaKeyStore(schema);
-    let subschema = service.findSubschema('anArray/innerArray');
+    let subschema = service.findSubschema('anArray.innerArray');
     expect(subschema).toEqual(expectedMap);
   });
 

--- a/src/app/shared/services/schema-keys-store.service.ts
+++ b/src/app/shared/services/schema-keys-store.service.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash';
 @Injectable()
 export class SchemaKeysStoreService {
 
-  public separator = '/';
+  public readonly separator = '.';
   public schemaKeyStoreMap: { [path: string]: OrderedSet<string> } = {};
   public recordKeysStoreMap: any = {};
   public schema = {};
@@ -60,7 +60,7 @@ export class SchemaKeysStoreService {
     if (path === '') {
       return subSchema;
     }
-    let splitPath = path.split('/');
+    let splitPath = path.split(this.separator);
     for (let index in splitPath) {
       if (subSchema['type'] === 'object') {
         if (subSchema['properties'][splitPath[index]]) {


### PR DESCRIPTION
(Closes #47)

Signed-off-by: Zacharias Zacharodimos <zacharias.zacharodimos@cern.ch>